### PR TITLE
Add getLastBlock

### DIFF
--- a/lib/rest.js
+++ b/lib/rest.js
@@ -331,6 +331,21 @@ function compile( compileList, node) {
   }
 }
 
+function getLastBlock(number, node) {
+  return function(scope) {
+    return new Promise(function(resolve, reject) {
+      verbose('getLastBlock', {number, node});
+      api.setNode(node);
+      return api.strato.last(number)
+        .then(function(block) {
+          if(scope.blocks == undefined) scope.blocks = [];
+          scope.blocks.push(block);
+          resolve(scope);
+        }).catch(errorify(reject));
+    });
+  }
+}
+
 function getAccount(address, node) {
   return function(scope) {
     return new Promise(function(resolve, reject) {
@@ -440,6 +455,7 @@ module.exports = {
   createUser: createUser,
   getAccount: getAccount,
   getBalance: getBalance,
+  getLastBlock: getLastBlock,
   getLastBlockNumber: getLastBlockNumber,
   getState: getState,
   getContractString: getContractString,

--- a/lib/rest.js
+++ b/lib/rest.js
@@ -331,10 +331,10 @@ function compile( compileList, node) {
   }
 }
 
-function getLastBlock(number, node) {
+function (number, node) {
   return function(scope) {
     return new Promise(function(resolve, reject) {
-      verbose('getLastBlock', {number, node});
+      verbose('', {number, node});
       api.setNode(node);
       return api.strato.last(number == undefined ? 0 : number)
         .then(function(block) {
@@ -377,17 +377,12 @@ function getBalance(address, node) {
 
 function getLastBlockNumber(node) {
   return function(scope) {
-    return new Promise(function(resolve, reject) {
-      verbose('getLastBlockNumber');
-      api.setNode(node);
-      return api.strato.last(0)
-        .then(function(result) {
-          const block = result[0];
-          verbose(`getLastBlockNumber: last # ${block.blockData.number}`);
-          scope.lastBlockNumber = block.blockData.number;
-          resolve(scope);
-      }).catch(errorify(reject));
-    });
+    verbose('getLastBlockNumber');
+    return getLastBlock(0, node)(scope)
+      .then(function(scope){
+        scope.lastBlockNumber = scope.blocks.slice(-1)[0][0].blockData.number;
+        return scope;
+      });
   };
 }
 

--- a/lib/rest.js
+++ b/lib/rest.js
@@ -336,7 +336,7 @@ function getLastBlock(number, node) {
     return new Promise(function(resolve, reject) {
       verbose('getLastBlock', {number, node});
       api.setNode(node);
-      return api.strato.last(number)
+      return api.strato.last(number == undefined ? 0 : number)
         .then(function(block) {
           if(scope.blocks == undefined) scope.blocks = [];
           scope.blocks.push(block);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "blockapps-rest",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "BlockApps rest api",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
getLackBlockNumber overwrites the last block number. This call pushes the results of the last block into `scope.blocks` and also accepts a number parameter. This is necessary for the network.e2e.test to check if all the nodes in a given network are in sync. 