### PR TITLE
Remove check for type of tx result in case of sendList

### DIFF
--- a/lib/rest.js
+++ b/lib/rest.js
@@ -228,7 +228,7 @@ function sendList(fromUser, txs, txresolve, node) {
           };
           scope.tx.push(tx);
           // verity results
-          verifyListResult(txs, txresolve, result);
+          verifyListResult(txs, txresolve, result, true);
           // succcess
           resolve(scope);
         }).catch(errorify(reject));
@@ -294,7 +294,7 @@ function callMethodList(fromUser, txs, txresolve, node) {
   }
 }
 
-function verifyListResult(txs, txresolve, result) {
+function verifyListResult(txs, txresolve, result, isSendList=false) {
   // if result is a string - error
   if (typeof result === 'string')
     throw new Error (`List result error: ${result}`);
@@ -302,12 +302,16 @@ function verifyListResult(txs, txresolve, result) {
   if (txs.length != result.length)
     throw new Error (`List result: size mismatch. Expected ${txs.length} actual ${result.length} `);
   // check resolved
-  if (txresolve) {
-    // resolved - result must be a list of objects
-    if (typeof result[0] === 'string') throw new Error('List result: resolved values must be objects');
-  } else {
-    // not resolved - result must be a list of hashes (strings)
-    if (typeof result[0] !== 'string') throw new Error('List result: non-resolved values must be hash strings');
+
+  // Send list always returns a list of objects. Even hashes are returned as a list of objects.
+  if(!isSendList) {
+    if (txresolve) {
+      // resolved - result must be a list of objects
+      if (typeof result[0] === 'string') throw new Error('List result: resolved values must be objects');
+    } else {
+      // not resolved - result must be a list of hashes (strings)
+      if (typeof result[0] !== 'string') throw new Error('List result: non-resolved values must be hash strings');
+    }
   }
 }
 


### PR DESCRIPTION
sendList returns the following when resolve = true

```
[
  {
    "senderBalance": "999999999999911419598"
  },
  {
    "senderBalance": "999999999999911419598"
  },
  {
    "senderBalance": "999999999999911419598"
  }
]
```

sendLIst returns the following when resolve = false

```
[
  {
    "senderBalance": "90ec63bcc2cfe62aaa179c83186d3136fac351ead09f060b81097b4e7ae8b831"
  },
  {
    "senderBalance": "863076cbde4928eb50b0bfe233f6b59f256d83b2855c7ad20845bc3847897bf7"
  },
  {
    "senderBalance": "7771c8a21f93d6549793cc727a550e6dae5dd90e098e84cfad43067b7e1ab890"
  }
]
```

The verifyListResult call was failing for sendList when resolve = false because a list of objects is returned in both cases.