### PR TITLE
Allow including imports in rest_5.js

### DIFF
--- a/lib/rest_5.js
+++ b/lib/rest_5.js
@@ -240,12 +240,14 @@ function* callList(user, txs, doNotResolve, node) {
  * @param{Boolean} doNotResolve tell bloc to wait for resolution or return immediately
  * @param{Object} txParams {gasLimit: Number, gasPrice: Number}
  * @param{Number} node target nodeId
+ * @param{Object} imports Names and sources of files imported in contractSrc, e.g. {"imp.sol": "contract Imp {}", ...}
  * @returns{()} doNotResolve=true: [transaction hash] (String), doNotResolve=false: [uploaded contract details]
 */
-function* uploadContractString(user, contractName, contractSrc, args, doNotResolve, txParams, node) {
+function* uploadContractString(user, contractName, contractSrc, args, doNotResolve, txParams, node, imports) {
   const resolve = (doNotResolve) ? false : true;
   args = args || {};
   txParams = txParams || {};
+  imports = imports || {};
   verbose('uploadContractString', {user, contractName, args, txParams, resolve, node});
 
   var result = yield api.bloc.contract({
@@ -254,6 +256,7 @@ function* uploadContractString(user, contractName, contractSrc, args, doNotResol
       args: args,
       contract: contractName,
       txParams: txParams,
+      imports: imports,
     }, user.name, user.address, resolve, node)
     .catch(function(e) {
       throw (e instanceof Error) ? e : new HttpError(e);
@@ -278,12 +281,17 @@ function* uploadContractString(user, contractName, contractSrc, args, doNotResol
   return result.hash;
 }
 
-function* uploadContract(user, contractName, contractFilename, args, doNotResolve, txParams, node) {
+function* uploadContract(user, contractName, contractFilename, args, doNotResolve, txParams, node, importFilenames) {
   verbose('uploadContract', {user, contractName, contractFilename, args, doNotResolve, txParams, node});
-  // get the source
+  // get the main source
   const contractSrc = yield getContractString(contractName, contractFilename);
+  // get the import sources
+  const srcImports = {}
+  for (const file in importFilenames) {
+    srcImports[file] = yield getContractString("<imported>", file);
+  }
   // upload
-  return yield uploadContractString(user, contractName, contractSrc, args, doNotResolve, txParams, node);
+  return yield uploadContractString(user, contractName, contractSrc, args, doNotResolve, txParams, node, srcImports);
 }
 
 /**


### PR DESCRIPTION
Note that while bloch will parse the JSON appropriately,
it does not yet know how to parse an import statement:
https://github.com/blockapps/blockapps-haskell/blob/84254030624bf7eabe4a15e766504e09889d4120/solidity/src/BlockApps/Solidity/Parse/File.hs#L25

See also https://github.com/blockapps/blockapps-haskell/pull/254, https://github.com/blockapps/blockapps-ba/pull/84