### PR TITLE
Handle pending

### DIFF
--- a/lib/rest_5.js
+++ b/lib/rest_5.js
@@ -274,6 +274,10 @@ function* uploadContractString(user, contractName, contractSrc, args, doNotResol
     if(result.status === constants.FAILURE) {
       throw new HttpError400(result.txResult.message);
     }
+    else if(result.status === constants.PENDING) {
+      return result;
+    }
+
     const address = result.data.contents.address;
 
     // validate address

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "blockapps-rest",
-    "version": "5.1.5",
+    "version": "5.1.6",
     "description": "BlockApps rest api",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
A change was made to Bloc recently that limits the number of polls it makes to Strato, preventing a 504 timeout error from happening, and gracefully terminating the Bloc API call. However, it is now possible for Bloc API calls to return a Pending result, even with resolve=true.
When this happens, instead of causing an unhandled exception, we return the result as is. This way, application developers can handle the Pending case safely.