### PR TITLE
Handle pending

### DIFF
--- a/lib/rest_5.js
+++ b/lib/rest_5.js
@@ -274,6 +274,10 @@ function* uploadContractString(user, contractName, contractSrc, args, doNotResol
     if(result.status === constants.FAILURE) {
       throw new HttpError400(result.txResult.message);
     }
+    else if(result.status === constants.PENDING) {
+      return result;
+    }
+
     const address = result.data.contents.address;
 
     // validate address

--- a/lib/rest_5.js
+++ b/lib/rest_5.js
@@ -179,6 +179,10 @@ function* call(user, contract, methodName, args, value, doNotResolve, node) {
   // When resolve=true, expect bloc to only return once transaction has either succeeded or failed.
   // When resolve=false, bloc will return the transaction hash immeidately, and it is the caller's responibility to check it.
   if(resolve) {
+    while (result.status === constants.PENDING) {
+        result = yield getBlocResult(result.hash, true);
+    }
+
     if(result.status === constants.FAILURE) {
       throw new HttpError400(result.txResult.message);
     }
@@ -214,7 +218,7 @@ function* callList(user, txs, doNotResolve, node) {
   verbose('callList', {user, txs, resolve, node});
 
   //callList: function(body, from, address) {
-  var results = yield api.bloc.callList({
+  const results = yield api.bloc.callList({
       password: user.password,
       txs: txs,
       resolve: resolve,
@@ -228,14 +232,16 @@ function* callList(user, txs, doNotResolve, node) {
   // When resolve=true, expect bloc to only return once transaction has either succeeded or failed.
   // When resolve=false, bloc will return the transaction hash immeidately, and it is the caller's responibility to check it.
   if(resolve) {
-    results.map(function(result){
+    const resolvedResults = yield resolveResults(results);
+
+    resolvedResults.map(function(result){
       if(result.status === constants.FAILURE) {
         throw new HttpError400(result.txResult.message);
       }
     });
-    return results.map(function(result){return result.data.contents;});
+    return resolvedResults.map(function(result){return result.data.contents;});
   }
-  return results.map(function(result){return result.hash;});
+  else return results.map(function(result){return result.hash;});
 }
 
 
@@ -271,11 +277,12 @@ function* uploadContractString(user, contractName, contractSrc, args, doNotResol
   // When resolve=true, expect bloc to only return once transaction has either succeeded or failed.
   // When resolve=false, bloc will return the transaction hash immeidately, and it is the caller's responibility to check it.
   if(resolve) {
+    while (result.status === constants.PENDING) {
+        result = yield getBlocResult(result.hash, true);
+    }
+
     if(result.status === constants.FAILURE) {
       throw new HttpError400(result.txResult.message);
-    }
-    else if(result.status === constants.PENDING) {
-      return result;
     }
 
     const address = result.data.contents.address;
@@ -322,12 +329,14 @@ function *  uploadContractList(user, txs, doNotResolve, node){
     });
 
   if(resolve) {
-    results.map(function(result){
-      if(result.status === constants.FAILURE) {
-        throw new HttpError400(result.txResult.message);
-      }
+    const resolvedResults = yield resolveResults(results);
+
+    resolvedResults.map(function(result){
+        if(result.status === constants.FAILURE) {
+            throw new HttpError400(result.txResult.message);
+        }
     });
-    return results.map(function(r){return r.data.contents;});
+    return resolvedResults.map(function(result){return result.data.contents;});
   }
   return results.map(function(r){return r.hash;});
 }
@@ -363,7 +372,7 @@ function* query(query, node) {
 function* send(fromUser, toUser, value, doNotResolve, nonce, node) {
   verbose('send', {fromUser, toUser, value, doNotResolve, node});
   const resolve = (doNotResolve) ? false : true;
-  const result = yield api.bloc.send({
+  var result = yield api.bloc.send({
       password: fromUser.password,
       toAddress: toUser.address,
       value: value,
@@ -376,6 +385,10 @@ function* send(fromUser, toUser, value, doNotResolve, nonce, node) {
   // When resolve=true, expect bloc to only return once transaction has either succeeded or failed.
   // When resolve=false, bloc will return the transaction hash immeidately, and it is the caller's responibility to check it.
   if(resolve) {
+    while (result.status === constants.PENDING) {
+        result = yield getBlocResult(result.hash, true);
+    }
+
     if(result.status === constants.FAILURE) {
       throw new HttpError400(result.txResult.message);
     }
@@ -402,12 +415,14 @@ function* sendList(fromUser, txs, doNotResolve, node) {
   // When resolve=true, expect bloc to only return once transaction has either succeeded or failed.
   // When resolve=false, bloc will return the transaction hash immeidately, and it is the caller's responibility to check it.
   if(resolve) {
-    results.map(function(r){
-      if(result.status === constants.FAILURE) {
-        throw new HttpError400(result.txResult.message);
-      }
+    const resolvedResults = yield resolveResults(results);
+
+    resolvedResults.map(function(result){
+        if(result.status === constants.FAILURE) {
+            throw new HttpError400(result.txResult.message);
+        }
     });
-    return results.map(function(r){return r.data.contents;});
+    return resolvedResults.map(function(result){return result.data.contents;});
   }
   return results.map(function(r){return r.hash;});
 }
@@ -434,6 +449,14 @@ function* getBlocResults(hashes, resolve, node) {
       throw (e instanceof Error) ? e : new HttpError(e);
     });
   return result;
+}
+
+function* resolveResults(results) {
+    var res = results;
+    while (res.filter(r => {return r.status === constants.PENDING}).length !== 0) {
+        res = yield getBlocResults(res.map(r => {return r.hash}), true);
+    }
+    return res;
 }
 
 function* transactionResult(hash, node) {
@@ -653,6 +676,7 @@ module.exports = {
   sendList: sendList,
   getBlocResult: getBlocResult,
   getBlocResults: getBlocResults,
+  resolveResults: resolveResults,
   transactionResult: transactionResult,
   waitQuery: waitQuery,
   waitTransactionResult: waitTransactionResult,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "blockapps-rest",
-    "version": "5.1.5",
+    "version": "5.1.6",
     "description": "BlockApps rest api",
     "main": "index.js",
     "scripts": {

--- a/test/upload.test.js
+++ b/test/upload.test.js
@@ -6,6 +6,7 @@ const config = common.config;
 const assert = common.assert;
 const util = common.util;
 const path = require('path');
+const constants = common.constants;
 
 describe('Upload contract list test', function(){
 
@@ -64,6 +65,31 @@ describe('Upload contract list test', function(){
     
   })
 
-  
+    it('should upload and resolve multiple contracts', function * () {
+        const response = yield rest.uploadContractList(user, txs, true);
+
+        const hashesAreValid = response.reduce((result, hash) => {
+            console.log(hash);
+            if(!result) {
+                return result;
+            }
+            return result && util.isTxHash(hash);
+        }, true)
+
+        assert.isOk(hashesAreValid, 'Should get back valid hashes');
+
+        const results = response.map(r => {return {hash: r}})
+        const resolved = yield rest.resolveResults(results)
+
+        const allAreResolved = resolved.reduce((result, res) => {
+            console.log(res)
+            if(!result) {
+                return result;
+            }
+            return result && (res.statue !== constants.PENDING)
+        }, true)
+
+        assert.isOk(allAreResolved, 'Should resolve all transactions');
+    })
 
 });


### PR DESCRIPTION
Every transaction endpoint can now return Pending, even with resolve=true. Therefore, blockapps-rest must handle the pending case for each endpoint.