### PR TITLE
Fix issue with import statement resolver and upgrade version

### DIFF
--- a/lib/importer.js
+++ b/lib/importer.js
@@ -142,7 +142,7 @@ function readFileLines(fullname) {
 // /
 function importFile(fullname, line) {
   var buffer = '//' + line + '\n';
-  var importName = line.split(' ')[1].replace(/\"/gi, '').replace(';', '');
+  var importName = line.replace(/import[\s]+/i, '').replace(/\"/gi, '').replace(';', '');
   importName = importName.replace('\r', '');  // Windows fix
   if (isImported(importName)) {
     buffer += '// exists\n';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "blockapps-rest",
-    "version": "5.2.4",
+    "version": "5.2.5",
     "description": "BlockApps rest api",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
Fixes an issue where parsing import statements of the type `import    'util.sol'` would cause errors because the importer assumes that there can be only one space. Replaced `split` with regex to prevent these issues.