### PR TITLE
 Solidity imports that start with '/' are treated as relative paths t…

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,10 @@
 ## RELEASE NOTES
 
+### Version: 5.2.5
+
+#### Minor upgrades
+* `importer` Solidity imports that start with '/' are treated as relative paths to the project root (process.cwd)
+
 ### Version: 5.2.4
 
 #### Minor upgrades

--- a/lib/importer.js
+++ b/lib/importer.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const nodepath = require('path');
+const cwd = nodepath.resolve(process.cwd());
 
 var nameStore = [];
 
@@ -147,6 +148,10 @@ function importFile(fullname, line) {
   if (isImported(importName)) {
     buffer += '// exists\n';
     return buffer;
+  }
+  // if import name starts with '/' - read relative to project root -LS
+  if (importName.indexOf('/') == 0) {
+    return buffer + readFileLines(nodepath.join(cwd, importName));
   }
   var parentPath = splitPath(fullname);
   return buffer + readFileLines(nodepath.join(parentPath, importName));

--- a/lib/util.js
+++ b/lib/util.js
@@ -29,7 +29,10 @@ function promiseWhile(Promise) {
 }
 
 function x(arg) {
-  console.log(arg); process.exit();
+  console.log('####################################### exit');
+  console.log(arg);
+  console.log('####################################### exit');
+  process.exit();
 }
 
 function* sleep(milli) {
@@ -265,7 +268,7 @@ module.exports = {
   usc: usc,
   sleep: sleep,
   wait: wait,
-  x: x, 
+  x: x,
 
   // generate a unique id
   uid: function(prefix, digits) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "blockapps-rest",
-    "version": "5.2.4",
+    "version": "5.2.5",
     "description": "BlockApps rest api",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
…… (#76)

*  Solidity imports that start with '/' are treated as relative paths to the project root (process.cwd)

* cleanup

* cleanup