### PR TITLE
Update eparser to get fields from imported solidity files

### DIFF
--- a/lib/eparser.js
+++ b/lib/eparser.js
@@ -65,9 +65,10 @@ function getImports(filename) {
 function getFieldsSync(filename, prefix) {
   const result = {};
   const graph = SolidityParser.parseFile(filename);
-  const contract0body = graph.body[0].body;
+  const contract = graph.body[graph.body.length - 1];
+  const contractbody = contract.body;
 
-  contract0body.filter(member => {
+  contractbody.filter(member => {
     // filter variables
     return member.type == 'ExpressionStatement' && member.expression.type == 'AssignmentExpression';
   }).filter(member => {
@@ -80,7 +81,7 @@ function getFieldsSync(filename, prefix) {
     result[member.expression.right.value] = member.expression.left.name;
   })
 
-  contract0body.filter(member => {
+  contractbody.filter(member => {
     // filter variablesle
     if (member.name == undefined || member.name == null) return false;
     if (member.value == undefined || member.value == null) return false;
@@ -96,7 +97,7 @@ function getFieldsSync(filename, prefix) {
     result[member.value.value] = member.name;
   })
 
-  contract0body.filter(member => {
+  contractbody.filter(member => {
     // filter StateVariableDeclaration array
     if (!member.type == 'StateVariableDeclaration') return false
     if (member.name == undefined || member.name == null) return false;
@@ -113,7 +114,43 @@ function getFieldsSync(filename, prefix) {
     });
   })
 
+  contract.is.map(is => {
+    const importedFileName = is.name;
+    const from = graph.body.filter(member => {
+      if(!member.from) return false;
+      return member.from.endsWith(`${importedFileName}.sol`); // assuming only solidity files will be imported
+    })[0].from;
+
+    return buildImportFilePath(from.split('/'), filename.split('/')).join('/'); // assuming only unix like directory separation
+  }).map(importFilePath => {
+    return getFieldsSync(importFilePath);
+  }).forEach(fields => {
+    Object.keys(fields).forEach(key => {
+      result[key] = fields[key];
+    })
+  })
   return(result);
+}
+
+function buildImportFilePath(fromPath, currentPath, fileSeparator) { // assuming relative path used
+  let currentIndex = currentPath.length - 1;
+  let fromIndex    = 0;
+
+  while (fromPath[fromIndex] === '..') {
+    currentIndex--;
+    fromIndex++;
+  }
+  if(fromPath[fromIndex] === '.') {
+    fromIndex++;
+  }
+
+  let newPath = currentPath.filter((p, index) => index <= currentIndex);
+
+  for(; fromIndex < fromPath.length; fromIndex++, currentIndex++) {
+    newPath[currentIndex] = fromPath[fromIndex];
+  }
+
+  return newPath;
 }
 
 module.exports = {

--- a/lib/eparser.js
+++ b/lib/eparser.js
@@ -1,4 +1,6 @@
 var SolidityParser = require("solidity-parser");
+var path = require('path');
+const separator = path.sep;
 
 // parse the file
 function parse(filename, enhanced) {
@@ -121,7 +123,7 @@ function getFieldsSync(filename, prefix) {
       return member.from.endsWith(`${importedFileName}.sol`); // assuming only solidity files will be imported
     })[0].from;
 
-    return buildImportFilePath(from.split('/'), filename.split('/')).join('/'); // assuming only unix like directory separation
+    return buildImportFilePath(from.split(separator), filename.split(separator)).join(separator);
   }).map(importFilePath => {
     return getFieldsSync(importFilePath);
   }).forEach(fields => {
@@ -132,7 +134,7 @@ function getFieldsSync(filename, prefix) {
   return(result);
 }
 
-function buildImportFilePath(fromPath, currentPath, fileSeparator) { // assuming relative path used
+function buildImportFilePath(fromPath, currentPath) { // assuming relative path used
   let currentIndex = currentPath.length - 1;
   let fromIndex    = 0;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "blockapps-rest",
-    "version": "5.3.1",
+    "version": "5.3.2",
     "description": "BlockApps rest api",
     "main": "index.js",
     "scripts": {

--- a/test/fixtures/UVW.sol
+++ b/test/fixtures/UVW.sol
@@ -1,0 +1,7 @@
+import "./second/LMN.sol";
+
+contract UVW is LMN {
+  uint constant U = 20;
+  uint constant V = 21;
+  uint constant W = 22;
+}

--- a/test/fixtures/first/first/ABC.sol
+++ b/test/fixtures/first/first/ABC.sol
@@ -1,0 +1,8 @@
+import "./XYZ.sol";
+import "./GHI.sol";
+
+contract ABC is XYZ, GHI {
+  uint constant A = 0;
+  uint constant B = 1;
+  uint constant C = 2;
+}

--- a/test/fixtures/first/first/GHI.sol
+++ b/test/fixtures/first/first/GHI.sol
@@ -1,0 +1,5 @@
+contract GHI {
+  uint constant G = 6;
+  uint constant H = 7;
+  uint constant I = 8;
+}

--- a/test/fixtures/first/first/XYZ.sol
+++ b/test/fixtures/first/first/XYZ.sol
@@ -1,0 +1,5 @@
+contract XYZ {
+  uint constant X = 23;
+  uint constant Y = 24;
+  uint constant Z = 25;
+}

--- a/test/fixtures/second/DEF.sol
+++ b/test/fixtures/second/DEF.sol
@@ -1,0 +1,7 @@
+import "../UVW.sol";
+
+contract DEF is UVW {
+  uint constant D = 3;
+  uint constant E = 4;
+  uint constant F = 5;
+}

--- a/test/fixtures/second/LMN.sol
+++ b/test/fixtures/second/LMN.sol
@@ -1,0 +1,7 @@
+import "./first/PQR.sol";
+
+contract LMN is PQR {
+  uint constant L = 11;
+  uint constant M = 12;
+  uint constant N = 13;
+}

--- a/test/fixtures/second/first/PQR.sol
+++ b/test/fixtures/second/first/PQR.sol
@@ -1,0 +1,7 @@
+import "../../first/first/ABC.sol";
+
+contract PQR is ABC {
+  uint constant P = 15;
+  uint constant Q = 16;
+  uint constant R = 17;
+}

--- a/test/import.test.js
+++ b/test/import.test.js
@@ -1,0 +1,59 @@
+require('co-mocha');
+const ba = require('../index');
+const rest = ba.rest;
+const common = ba.common;
+const assert = common.assert;
+
+const DEF = rest.getFields(`./test/fixtures/second/DEF.sol`);
+
+
+describe('Fetch contract fields', function(){
+
+  it('should get all the fields', function * () {
+
+    const expected = { '0': 'A',
+      '1': 'B',
+      '2': 'C',
+      '3': 'D',
+      '4': 'E',
+      '5': 'F',
+      '6': 'G',
+      '7': 'H',
+      '8': 'I',
+      '11': 'L',
+      '12': 'M',
+      '13': 'N',
+      '15': 'P',
+      '16': 'Q',
+      '17': 'R',
+      '20': 'U',
+      '21': 'V',
+      '22': 'W',
+      '23': 'X',
+      '24': 'Y',
+      '25': 'Z',
+      D: 3,
+      E: 4,
+      F: 5,
+      U: 20,
+      V: 21,
+      W: 22,
+      L: 11,
+      M: 12,
+      N: 13,
+      P: 15,
+      Q: 16,
+      R: 17,
+      A: 0,
+      B: 1,
+      C: 2,
+      X: 23,
+      Y: 24,
+      Z: 25,
+      G: 6,
+      H: 7,
+      I: 8 };
+    assert.equal(JSON.stringify(DEF), JSON.stringify(expected));
+  })
+
+});


### PR DESCRIPTION
Currently the fields present in the imported solidity files are not fetched by the `getFieldsSync()`