### PR TITLE
Make intToBytes32 convert number passed as string

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -465,19 +465,23 @@ module.exports = {
   },
 
   /**
-   * convert int to bytes32
+   * Convert the given integer number into a bytes32. Return the result as a hex string.
    *
    * @method intToBytes32
-   * @param {int} integer value
-   * @return {bytes32}
+   * @param {number|string} value a number or a string representing a number
+   * @returns {string} a hex string
+   * @throws {Error} the value can not be converted to an integer number
    */
-  intToBytes32: function(int) {
+  intToBytes32: function(value) {
+    const int = Number(value);
+    if (!Number.isInteger(int)) throw new Error(`Not an integer: ${value}`);
+
     if (int < 0) {
       const string = negativeHexString(int);
-      return (Array(64).join('f')).slice(string.length - 1) + string
+      return string.padStart(64, 'f');
     }
-    const string = int.toString(16)
-    return (Array(64).join('0')).slice(string.length - 1) + string
-  }
 
+    const string = int.toString(16)
+    return string.padStart(64, '0');
+  }
 };

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -26,12 +26,46 @@ function positiveBytes(b,w) {
 }
 
 describe('util tests', function() {
-  it('converts negative numbers to and from hex', function() {
-    for(var k=0;k < 10000; k++) {
-      const n = Math.floor((Math.random() * MAX) - MAX/2);
-      const b = util.intToBytes32(n);
-      const m = bytes32ToInt(b);
-      m.should.equal(n);
-    }
+  describe('intToBytes32', function() {
+    // bytes32(9) as a hex string
+    const expectedResultFor9 = '0000000000000000000000000000000000000000000000000000000000000009';
+    // bytes32(17) as a hex string
+    const expectedResultFor17 = '0000000000000000000000000000000000000000000000000000000000000011';
+
+
+    it('converts negative numbers to and from hex', function() {
+      for(var k=0;k < 10000; k++) {
+        const n = Math.floor((Math.random() * MAX) - MAX/2);
+        const b = util.intToBytes32(n);
+        const m = bytes32ToInt(b);
+        m.should.equal(n);
+      }
+    });
+
+    it('Converting number', function() {
+      const resultFor9 = util.intToBytes32(9);
+      resultFor9.should.equal(expectedResultFor9, 'converting 9');
+      const resultFor17 = util.intToBytes32(17);
+      resultFor17.should.equal(expectedResultFor17, 'converting 17');
+    });
+
+    it('Converting number -- fails if non-integer', function() {
+      (() => util.intToBytes32(17.1)).should.throw(Error);
+    });
+
+    it('Converting string', function() {
+      const resultFor9 = util.intToBytes32('9');
+      resultFor9.should.equal(expectedResultFor9, 'converting 9');
+      const resultFo17 = util.intToBytes32('17');
+      resultFo17.should.equal(expectedResultFor17, 'converting 17');
+    });
+
+    it('Converting string -- fails if not a number', function() {
+      (() => util.intToBytes32('not a number')).should.throw(Error);
+    });
+
+    it('Converting string -- fails if non-integer', function() {
+      (() => util.intToBytes32('17.1')).should.throw(Error);
+    });
   });
 });


### PR DESCRIPTION
If you pass a string instead of a number into existing intToBytes32 implementation you won't get any error but the result will be invalid. For example:
```javascript
const valid = intToBytes32(17); // '0000000000000000000000000000000000000000000000000000000000000011'
const invalid = intToBytes32('17'); // '0000000000000000000000000000000000000000000000000000000000000017'
```
This PR addresses that issue:
 - make intToBytes32 convert numbers passed as strings correctly;
 - throw an exception if the passed value can not be converted to an integer number.