### PR TITLE
Chain options

### DIFF
--- a/lib/api_6.js
+++ b/lib/api_6.js
@@ -218,7 +218,10 @@ module.exports = function(config) {
       },
       keystore: function(body, name, node) {
         return ax.post(config.getBlocUrl(node), body, '/users/' + name + '/' + '/keystore');
-      }
+      },
+      details:function(address, chainId, node){
+        return ax.get(config.getBlocUrl(node), '/contracts/contract/' + address + '/details?chainid=' + chainId);
+      },
     },
 
     strato23: {

--- a/lib/rest_6.js
+++ b/lib/rest_6.js
@@ -803,18 +803,18 @@ function* getChainInfos(chainIds, node) {
  * @param{Number} node target node
  * @returns{()} ChainId
  */
-function* createChain(label, members, balances, src, args, options={}, contract, node) {
-  verbose('createChain', {label, members, balances, src, args, contract, node});
+function* createChain(label, members, balances, src, args, options={}) {
+  verbose('createChain', {label, members, balances, src, args, options});
   const body = {
     label: label,
     members: members,
     balances: balances,
     src: src,
     args: args,
-    metadata: constructMetadata(options, contract),
-    contract: contract
+    metadata: constructMetadata(options, options.contract),
+    contract: options.contract
   }
-  const chainId = yield api.bloc.createChain(body, node)
+  const chainId = yield api.bloc.createChain(body, options.node)
     .catch(function(e) {
       throw (e instanceof Error) ? e : new HttpError(e);
     });

--- a/lib/rest_6.js
+++ b/lib/rest_6.js
@@ -798,11 +798,12 @@ function* getChainInfos(chainIds, node) {
  * @param{Array} member initial balance
  * @param{String} contract string
  * @param{Object} contract instance variables
+ * @param{Object} options flags for history and indexing
  * @param{String} governance contract name
  * @param{Number} node target node
  * @returns{()} ChainId
  */
-function* createChain(label, members, balances, src, args, contract, node) {
+function* createChain(label, members, balances, src, args, options={}, contract, node) {
   verbose('createChain', {label, members, balances, src, args, contract, node});
   const body = {
     label: label,
@@ -810,6 +811,7 @@ function* createChain(label, members, balances, src, args, contract, node) {
     balances: balances,
     src: src,
     args: args,
+    metadata: constructMetadata(options, contract),
     contract: contract
   }
   const chainId = yield api.bloc.createChain(body, node)

--- a/lib/rest_6.js
+++ b/lib/rest_6.js
@@ -799,8 +799,6 @@ function* getChainInfos(chainIds, node) {
  * @param{String} contract string
  * @param{Object} contract instance variables
  * @param{Object} options flags for history and indexing
- * @param{String} governance contract name
- * @param{Number} node target node
  * @returns{()} ChainId
  */
 function* createChain(label, members, balances, src, args, options={}) {


### PR DESCRIPTION
Add options to the `createChain` function, to allow for governance contract history to be enabled. These options work the same way as options in other blockapps-rest functions.