### PR TITLE
Query state

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 ## RELEASE NOTES
 
+### Version 6.2.10
+* Call waitQuery in getState instead of api.bloc.state
+* Call waitQuery in getStateVar instead of api.bloc.stateVar
+
 ### Version 6.2.9
 * Fixed broken logger
 

--- a/lib/rest_5.js
+++ b/lib/rest_5.js
@@ -52,10 +52,10 @@ function* getState(contract, options={}) {
   return states[0];
 }
 
-function* getStateVar(contract, varName, varCount, varOffset, varLength, options={}) {
-  verbose('getStateVar', {contract, varName, varCount, varOffset, varLength, options});
-  const chainQuery = options.chainId ? `&chainId=eq.${options.chainId}` : '';
-  const states = yield waitQuery(`${contract.name}?address=eq.${contract.address}&select=${varName}`+chainQuery, 1, 60*1000, options.node);
+function* getStateVar(contract, varName, varCount, varOffset, varLength, chainId, node) {
+  verbose('getStateVar', {contract, varName, varCount, varOffset, varLength, chainId, node});
+  const chainQuery = chainId ? `&chainId=eq.${chainId}` : '';
+  const states = yield waitQuery(`${contract.name}?address=eq.${contract.address}&select=${varName}`+chainQuery, 1, 60*1000, node);
   if (typeof states[0] === 'string') {
     if (varLength) {
       return state[0].length;

--- a/lib/rest_5.js
+++ b/lib/rest_5.js
@@ -45,22 +45,32 @@ function getFields(path, prefix) {
 }
 
 // ========= bf ==========
-function* getState(contract, chainId, node) {
-  verbose('getState', {contract, chainId, node});
-  const state = yield api.bloc.state(contract.name, contract.address, chainId, node)
+function* getState(contract, options={}) {
+  verbose('getState', {contract, options});
+  const chainQuery = options.chainId ? `&chainId=eq.${options.chainId}` : '';
+  const states = yield waitQuery(`${contract.name}?address=eq.${contract.address}`+chainQuery, 1, 60*1000, options.node)
     .catch(function(e) {
       throw (e instanceof Error) ? e : new HttpError(e);
     });
-  return state;
+  return states[0];
 }
 
-function* getStateVar(contract, varName, varCount, varOffset, varLength, chainId, node) {
-  verbose('getState', {contract, varName, varCount, varOffset, varLength, chainId, node});
-  const state = yield api.bloc.stateVar(contract.name, contract.address, varName, varCount, varOffset, varLength, chainId, node)
+function* getStateVar(contract, varName, varCount, varOffset, varLength, options={}) {
+  verbose('getStateVar', {contract, varName, varCount, varOffset, varLength, options});
+  const chainQuery = options.chainId ? `&chainId=eq.${options.chainId}` : '';
+  const states = yield waitQuery(`${contract.name}?address=eq.${contract.address}&select=${varName}`+chainQuery, 1, 60*1000, options.node)
     .catch(function(e) {
       throw (e instanceof Error) ? e : new HttpError(e);
     });
-  return state;
+  if (typeof states[0] === 'string') {
+    if (varLength) {
+      return state[0].length;
+    } else {
+      return state[0].substring(varOffset, varOffset+varCount);
+    }
+  } else {
+    return states[0];
+  }
 }
 
 class RestError extends Error {

--- a/lib/rest_5.js
+++ b/lib/rest_5.js
@@ -48,20 +48,14 @@ function getFields(path, prefix) {
 function* getState(contract, options={}) {
   verbose('getState', {contract, options});
   const chainQuery = options.chainId ? `&chainId=eq.${options.chainId}` : '';
-  const states = yield waitQuery(`${contract.name}?address=eq.${contract.address}`+chainQuery, 1, 60*1000, options.node)
-    .catch(function(e) {
-      throw (e instanceof Error) ? e : new HttpError(e);
-    });
+  const states = yield waitQuery(`${contract.name}?address=eq.${contract.address}`+chainQuery, 1, 60*1000, options.node);
   return states[0];
 }
 
 function* getStateVar(contract, varName, varCount, varOffset, varLength, options={}) {
   verbose('getStateVar', {contract, varName, varCount, varOffset, varLength, options});
   const chainQuery = options.chainId ? `&chainId=eq.${options.chainId}` : '';
-  const states = yield waitQuery(`${contract.name}?address=eq.${contract.address}&select=${varName}`+chainQuery, 1, 60*1000, options.node)
-    .catch(function(e) {
-      throw (e instanceof Error) ? e : new HttpError(e);
-    });
+  const states = yield waitQuery(`${contract.name}?address=eq.${contract.address}&select=${varName}`+chainQuery, 1, 60*1000, options.node);
   if (typeof states[0] === 'string') {
     if (varLength) {
       return state[0].length;

--- a/lib/rest_6.js
+++ b/lib/rest_6.js
@@ -82,20 +82,30 @@ function getFields(path, prefix) {
 // ========= bf ==========
 function* getState(contract, options={}) {
   verbose('getState', {contract, options});
-  const state = yield api.bloc.state(contract.name, contract.address, options.chainId, options.node)
+  const chainQuery = options.chainId ? `&chainId=eq.${options.chainId}` : '';
+  const states = yield waitQuery(`${contract.name}?address=eq.${contract.address}`+chainQuery, 1, 60*1000, options.node)
     .catch(function(e) {
       throw (e instanceof Error) ? e : new HttpError(e);
     });
-  return state;
+  return states[0];
 }
 
 function* getStateVar(contract, varName, varCount, varOffset, varLength, options={}) {
   verbose('getStateVar', {contract, varName, varCount, varOffset, varLength, options});
-  const state = yield api.bloc.stateVar(contract.name, contract.address, varName, varCount, varOffset, varLength, options.chainId, options.node)
+  const chainQuery = options.chainId ? `&chainId=eq.${options.chainId}` : '';
+  const states = yield waitQuery(`${contract.name}?address=eq.${contract.address}&select=${varName}`+chainQuery, 1, 60*1000, options.node)
     .catch(function(e) {
       throw (e instanceof Error) ? e : new HttpError(e);
     });
-  return state;
+  if (typeof states[0] === 'string') {
+    if (varLength) {
+      return state[0].length;
+    } else {
+      return state[0].substring(varOffset, varOffset+varCount);
+    }
+  } else {
+    return states[0];
+  }
 }
 
 class RestError extends Error {

--- a/lib/rest_6.js
+++ b/lib/rest_6.js
@@ -83,20 +83,14 @@ function getFields(path, prefix) {
 function* getState(contract, options={}) {
   verbose('getState', {contract, options});
   const chainQuery = options.chainId ? `&chainId=eq.${options.chainId}` : '';
-  const states = yield waitQuery(`${contract.name}?address=eq.${contract.address}`+chainQuery, 1, 60*1000, options.node)
-    .catch(function(e) {
-      throw (e instanceof Error) ? e : new HttpError(e);
-    });
+  const states = yield waitQuery(`${contract.name}?address=eq.${contract.address}`+chainQuery, 1, 60*1000, options.node);
   return states[0];
 }
 
 function* getStateVar(contract, varName, varCount, varOffset, varLength, options={}) {
   verbose('getStateVar', {contract, varName, varCount, varOffset, varLength, options});
   const chainQuery = options.chainId ? `&chainId=eq.${options.chainId}` : '';
-  const states = yield waitQuery(`${contract.name}?address=eq.${contract.address}&select=${varName}`+chainQuery, 1, 60*1000, options.node)
-    .catch(function(e) {
-      throw (e instanceof Error) ? e : new HttpError(e);
-    });
+  const states = yield waitQuery(`${contract.name}?address=eq.${contract.address}&select=${varName}`+chainQuery, 1, 60*1000, options.node);
   if (typeof states[0] === 'string') {
     if (varLength) {
       return state[0].length;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "blockapps-rest",
-    "version": "6.2.9",
+    "version": "6.2.10",
     "description": "BlockApps rest api",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
Querying Cirrus for contract state should now be the preferred method of retrieving contract state, rather than calling the Bloc /state route. This is because it is possible to query the state of a contract before it has been added to Bloc's database via Slipstream, leading to unexpected HttpErrors. This also saves a call to the Strato /storage route each time, as the Bloc /state route must decode the contract's raw storage into human-readable Solidity values. However, the Bloc /state route is still available via api.bloc.state and api.bloc.stateVar, should it be necessary to call them.
Instead of querying Cirrus, it would be acceptable to wrap the call to Bloc /state in `until`, preventing failures due to the aforementioned race condition, and guaranteeing that the returned state is the most current state, in the case Cirrus is running behind. However, this still suffers the performance disadvantage of parsing the contract state from raw storage every time the function is called.