### PR TITLE
Refer to `config` through `common`, as `config` is not imported

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,8 @@
 ## RELEASE NOTES
 
+### Version 6.2.13
+* Fix a resolution error introduced in 6.2.12
+
 ### Version 6.2.12
 * VM Selection is provided as well in config.yaml, with precedence given to `options`
   parameter in the function call in `rest_6`. In `rest_5`, this is the sole way to select

--- a/lib/rest_5.js
+++ b/lib/rest_5.js
@@ -290,8 +290,8 @@ function* uploadContractString(user, contractName, contractSrc, args, doNotResol
   txParams = txParams || {};
   verbose('uploadContractString', {user, contractName, args, txParams, resolve, chainId, node});
   const metadata = {};
-  if (config.VM !== undefined) {
-    metadata['VM'] = config.VM;
+  if (common.config.VM !== undefined) {
+    metadata['VM'] = common.config.VM;
   }
   var result = yield api.bloc.contract({
       password: user.password,

--- a/lib/rest_6.js
+++ b/lib/rest_6.js
@@ -62,8 +62,8 @@ function constructMetadata(options, contractName) {
 
   if (options.hasOwnProperty('VM')) {
     metadata['VM'] = options['VM'];
-  } else if (config.hasOwnProperty('VM')) {
-    metadata['VM'] = config['VM'];
+  } else if (common.config.hasOwnProperty('VM')) {
+    metadata['VM'] = common.config['VM'];
   }
 
   //TODO: construct the "nohistory" and "index" fields for metadata if needed


### PR DESCRIPTION
```  0 passing (5s)
  1 failing
  1) Supply Chain Demo App - deploy contracts should upload the contracts:
     ReferenceError: config is not defined
      at uploadContractString (node_modules/blockapps-rest/lib/rest_5.js:293:3)
      at uploadContractString.next (<anonymous>)
      at onFulfilled (node_modules/co/index.js:65:19)
      at node_modules/co/index.js:54:5
      at new Promise (<anonymous>)
      at Context.co (node_modules/co/index.js:50:10)
      at Context.toPromise (node_modules/co/index.js:118:63)
      at next (node_modules/co/index.js:99:29)
      at onFulfilled (node_modules/co/index.js:69:7)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:189:7)
```